### PR TITLE
Feature/coords page api

### DIFF
--- a/scripts/serializers.py
+++ b/scripts/serializers.py
@@ -26,6 +26,7 @@ class PageSerializer(serializers.ModelSerializer):
 
 class CoordinatesSerializer(serializers.ModelSerializer):
     page = PageSerializer(read_only=True)
+
     class Meta:
         model = Coordinates
         fields = ('id', 'page', 'letter', 'top', 'left', 'width', 'height',

--- a/scripts/serializers.py
+++ b/scripts/serializers.py
@@ -25,7 +25,8 @@ class PageSerializer(serializers.ModelSerializer):
 
 
 class CoordinatesSerializer(serializers.ModelSerializer):
+    page = PageSerializer(read_only=True)
     class Meta:
         model = Coordinates
         fields = ('id', 'page', 'letter', 'top', 'left', 'width', 'height',
-                  'binary_url')
+                  'binary_url', 'page')

--- a/scripts/views.py
+++ b/scripts/views.py
@@ -52,7 +52,6 @@ class PageDetail(generics.RetrieveAPIView):
 
 
 class CoordinatesList(generics.ListAPIView):
-    queryset = Coordinates.objects.all()
     serializer_class = CoordinatesSerializer
 
     def get_queryset(self):


### PR DESCRIPTION
This update adds information to the data returned by the API about a letter instance (aka a "coords" object); specifically, it nests more data about the letter's source page (including its manuscript) under the "page" key. These items live in two different DB tables and thus would otherwise require two API calls to access them; combining them in this way greatly reduces the complexity of the API queries the React app needs to make, while doing so in a way that won't offend Django purists.