### PR TITLE
API support for cropping manuscript page images

### DIFF
--- a/scriptchart/urls.py
+++ b/scriptchart/urls.py
@@ -15,7 +15,8 @@ urlpatterns = [
     path('api/pages', scripts.views.PageList.as_view()),
     path('api/pages/<int:pk>', scripts.views.PageDetail.as_view()),
     path('api/coordinates', scripts.views.CoordinatesList.as_view()),
-    path('api/coordinates/<int:pk>', scripts.views.CoordinatesDetail.as_view())
+    path('api/coordinates/<int:pk>', scripts.views.CoordinatesDetail.as_view()),
+    path('api/crop', scripts.views.LetterImage.as_view())
 ]
 
 urlpatterns = format_suffix_patterns(urlpatterns)

--- a/scripts/views.py
+++ b/scripts/views.py
@@ -8,9 +8,8 @@ from scripts.serializers import PageSerializer
 from scripts.models import Coordinates
 from scripts.serializers import CoordinatesSerializer
 
-from scripts.utils import create_letter_zip
-from django.http import HttpResponseRedirect, HttpResponse
-from PIL import Image, ImageFile
+from django.http import HttpResponse
+from PIL import Image
 import requests
 from io import BytesIO
 
@@ -18,11 +17,15 @@ from io import BytesIO
 class LetterImage(generics.ListAPIView):
     def get(self, request, format=None):
         page_url = self.request.GET.get('page_url')
+        x = int(self.request.GET.get('x') or 0)
+        y = int(self.request.GET.get('y') or 0)
+        w = int(self.request.GET.get('w') or 0)
+        h = int(self.request.GET.get('h') or 0)
         url = requests.get(page_url, verify=False)
         image = Image.open(BytesIO(url.content))
-        #response = HttpResponse(image, content_type="image/png")
+        image_crop = image.crop([x, y, x + w, y + h])
         response = HttpResponse(content_type="image/png")
-        image.save(response, "PNG")
+        image_crop.save(response, "PNG")
         response['Content-Length'] = len(response.content)
         return response
 

--- a/scripts/views.py
+++ b/scripts/views.py
@@ -8,6 +8,24 @@ from scripts.serializers import PageSerializer
 from scripts.models import Coordinates
 from scripts.serializers import CoordinatesSerializer
 
+from scripts.utils import create_letter_zip
+from django.http import HttpResponseRedirect, HttpResponse
+from PIL import Image, ImageFile
+import requests
+from io import BytesIO
+
+
+class LetterImage(generics.ListAPIView):
+    def get(self, request, format=None):
+        page_url = self.request.GET.get('page_url')
+        url = requests.get(page_url, verify=False)
+        image = Image.open(BytesIO(url.content))
+        #response = HttpResponse(image, content_type="image/png")
+        response = HttpResponse(content_type="image/png")
+        image.save(response, "PNG")
+        response['Content-Length'] = len(response.content)
+        return response
+
 
 class ManuscriptList(generics.ListAPIView):
     serializer_class = ManuscriptSerializer


### PR DESCRIPTION
This functionality is necessary to be able to display a cropped version of the original manuscript page, showing a particular letter instance and an arbitrarily sized contextual margin around it, when the cropped/binarized version of the letter instance is clicked or moused over in the scriptchart.
This implementation is based on @versae's utility scripts for excerpting letter instances for display in the admin interface. It's a bit experimental and probably could be made more efficient, but it works OK.