### PR TITLE
Fix error in pages search form, modify names of downloaded archive files

### DIFF
--- a/scripts/admin.py
+++ b/scripts/admin.py
@@ -116,7 +116,7 @@ class DownloadCoordinatesMixin:
                                 content_type="application/zip")
         response['Content-Length'] = len(response.content)
         response['Content-Disposition'] = (
-            f'attachment; filename=Coordinates@{datetime.datetime.now()}.zip'
+            f'attachment; filename="Coordinates@{datetime.datetime.now()}.zip"'
         )
         return response
     download_as_zip.short_description = "Download selected"
@@ -173,7 +173,7 @@ class PageAdmin(admin.ModelAdmin):
         'manuscript'
     )
     list_editable = ('url', 'manuscript', 'number')
-    search_fields = ('url', 'manuscript', 'number')
+    search_fields = ('url', 'manuscript__page', 'number')
     autocomplete_fields = ('manuscript', )
     inlines = (CoordinatesInline, )
     date_hierarchy = 'modified_date'
@@ -228,7 +228,7 @@ class PageAdmin(admin.ModelAdmin):
         response = HttpResponse(zip_file.getvalue(),
                                 content_type="application/zip")
         response['Content-Length'] = len(response.content)
-        response['Content-Disposition'] = f'attachment; filename={page}.zip'
+        response['Content-Disposition'] = f'attachment; filename="{page}.zip"'
         return response
 
     def get_urls(self):

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -43,7 +43,7 @@ def create_letter_zip(coordinates):
             last_url = coordinate.page.url
         x, w = coordinate.left, coordinate.width
         y, h = coordinate.top, coordinate.height
-        cid, letter = coordinate.id, coordinate.letter
+        letter = coordinate.letter
         page_name = (f"{coordinate.page.manuscript.shelfmark}_"
                      f"{coordinate.page.number}")
         image_name = f"{page_name}_{letter}_{x}_{y}_{w}_{h}.png"

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -46,7 +46,7 @@ def create_letter_zip(coordinates):
         cid, letter = coordinate.id, coordinate.letter
         page_name = (f"{coordinate.page.manuscript.shelfmark}_"
                      f"{coordinate.page.number}")
-        image_name = f"{page_name}_{x}_{y}_{w}_{h}_{letter}_{cid}.png"
+        image_name = f"{page_name}_{letter}_{x}_{y}_{w}_{h}.png"
         image_patch = BytesIO()
         image_crop = image.crop([x, y, x + w, y + h])
         image_crop.save(image_patch, format='PNG')


### PR DESCRIPTION
This update fixes a bug that was causing a 500 error when using the search field in the 'pages' view.
It also modifies the format of the letter image files downloaded in a ZIP archive from the 'coordinates' list. These files will be used to generate binarized versions, and so their naming convention has been modified to follow that of the existing binarized image files:
`{ms_shelfmark}_{page}_{letter}_{x}_{y}_{w}_{h}.png`
Also, the code to generate the file download was modified to add the '.zip' extension to the file.