### PR TITLE
Use certificate verification for https requests

### DIFF
--- a/.env_template
+++ b/.env_template
@@ -73,3 +73,15 @@ STATIC_URL=<static_url>
 # defaults to an empty list, and is not required for dev instances
 
 ADMINS=<admins>
+
+
+# IMAGES_ROOT
+# -----------
+#
+# This is an optional setting that specifies the folder in which manuscript
+#  page images can be found.  If specified, the crop API endpoint (only
+#  used in the admin site) will load the images directly from the
+#  filesystem -- if not set, it will get them over HTTP instead.  A folder
+#  called `manuscripts` is expected in the top level of IMAGES_ROOT.
+
+IMAGES_ROOT=</path/to/images>

--- a/scriptchart/settings.py
+++ b/scriptchart/settings.py
@@ -155,6 +155,7 @@ WHITENOISE_AUTOREFRESH = DEBUG
 STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 STATIC_ROOT = os.getenv('STATIC_ROOT', 'static')
 STATIC_URL = os.getenv('STATIC_URL', '/static/')
+IMAGES_ROOT = os.getenv('IMAGES_ROOT', None)
 
 ADMINS = [tuple(_.split(',')) for _ in os.getenv('ADMINS', None).split(';')] \
             if os.getenv('ADMINS', None) else []

--- a/scripts/tests/tests.py
+++ b/scripts/tests/tests.py
@@ -63,7 +63,7 @@ class CoordinatesTests(APITestCase):
 
 class CroppingTests(APITestCase):
     def test_image_crop(self):
-        url = '/api/crop?page_url=http://images.syriac.reclaim.hosting/'
+        url = '/api/crop?page_url=https://images.syriac.reclaim.hosting/'
         url += 'manuscripts/Add.17224/add17724-57a.jpg&x=879&y=1384&w=111&h=97'
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/scripts/views.py
+++ b/scripts/views.py
@@ -19,7 +19,7 @@ class LetterImage(generics.ListAPIView):
         y = int(self.request.GET.get('y') or 0)
         w = int(self.request.GET.get('w') or 0)
         h = int(self.request.GET.get('h') or 0)
-        url = requests.get(page_url, verify=False)
+        url = requests.get(page_url, verify=True)
         image = Image.open(BytesIO(url.content))
         image_crop = image.crop([x, y, x + w, y + h])
         response = HttpResponse(content_type="image/png")


### PR DESCRIPTION
Closes #43.

I spend some time researching creating a `urllib3.PoolManager` to verify requests:

    http = requests.packages.urllib3.PoolManager(
        cert_reqs='CERT_REQUIRED',
        ca_certs=certifi.where()
    )

vs. suppressing warnings:

    requests.packages.urllib3.disable_warnings(
        requests.packages.urllib3.InsecureRequestWarning)

(note that these operations must be performed used the version of `urllib3` vendored in to the `requests` package to have any effect).

However, I was puzzled as to why any of this was necessary.  Turns out, all that was required was to change `verify=False` to `verify=True` when making the request...  I'm not sure why certificate verification was explicitly turned off, but I've done a fair amount of research and testing by this stage, and I can't see any problems just using the default `verify=True`.

In the process of looking into this, it occurred to me that it's a bit crazy to be making a HTTPS request to get files that are stored on the same filesystem...  So the second commit in the PR allows the specification of a local copy of the manuscript page images.  If such a path is available, files will be loaded directly from disk rather than over HTTPS (should speed the admin interface up a little, even though the front-end won't be using this endpoint any more).  The original behaviour is preserved if no value is set, so that the admin interface will work on instances stood up on systems that don't have a full local copy of the page images.