### PR TITLE
Fix/certificate verification

### DIFF
--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -38,7 +38,7 @@ def create_letter_zip(coordinates):
     last_url = ""
     for coordinate in coordinates:
         if last_url != coordinate.page.url:
-            url = requests.get(coordinate.page.url, verify=False)
+            url = requests.get(coordinate.page.url, verify=True)
             image = Image.open(BytesIO(url.content))
             last_url = coordinate.page.url
         x, w = coordinate.left, coordinate.width


### PR DESCRIPTION
I missed one call to `requests.get` that had explicitly set `verify=False` (for reasons unclear).  This PR corrects that.

(Edit: this is really a logging issue only, so there's no hurry whatsoever with this, and it can be merged next week sometime if that suits.)